### PR TITLE
feat: dereference page offres (#68)

### DIFF
--- a/content/offres/index.md
+++ b/content/offres/index.md
@@ -2,11 +2,6 @@
 title: Offres
 layout: layouts/page.njk
 showBreadcrumb: true
-eleventyNavigation:
-    key: Offres
-    order: 3
-    permalink: "/offres"
-    nav: main
 ---
 
 <div class="fr-col-12 fr-col-lg-8">

--- a/content/plan-du-site/index.md
+++ b/content/plan-du-site/index.md
@@ -33,9 +33,6 @@ showBreadcrumb: true
             </ul>
           </li>
           <li>
-            <a href="/offres"> Offres </a>
-          </li>
-          <li>
             <a href="/actualites"> Actualités </a>
           </li>
           <li>


### PR DESCRIPTION
Retire la page offres de la navigation, en la conservant néanmoins accessible en attendant que son contenu soit repris et clarifié ailleurs.

refs #68 