### PR TITLE
chore: copie les favicons à la racine

### DIFF
--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -7,10 +7,10 @@
 
   <meta name="description" content="{{ description or metadata.description }}">
   <meta name="theme-color" content="#000091">
-  <link rel="apple-touch-icon" href="/favicon/apple-touch-icon.png"><!-- 180×180 -->
-  <link rel="icon" href="/favicon/favicon.svg" type="image/svg+xml">
-  <link rel="shortcut icon" href="/favicon/favicon.ico" type="image/x-icon"><!-- 32×32 -->
-  <link rel="manifest" href="/favicon/manifest.webmanifest" crossorigin="use-credentials">
+  <link rel="apple-touch-icon" href="/apple-touch-icon.png"><!-- 180×180 -->
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+  <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon"><!-- 32×32 -->
+  <link rel="manifest" href="/manifest.webmanifest" crossorigin="use-credentials">
 
   {#- Atom and JSON feeds included by default #}
   <link rel="alternate" href="/feed/feed.xml" type="application/atom+xml" title="{{ metadata.title }}">

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -20,9 +20,6 @@ const customMarkdownContainers = require("./markdown-custom-containers");
 
 const { getSummaryItems } = require("./utils.js");
 
-const fs = require("node:fs/promises");
-const path = require("node:path");
-
 module.exports = function (eleventyConfig) {
     // Copy the contents of the `public` folder to the output folder
     // For example, `./public/css/` ends up in `_site/css/`

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -20,6 +20,9 @@ const customMarkdownContainers = require("./markdown-custom-containers");
 
 const { getSummaryItems } = require("./utils.js");
 
+const fs = require("node:fs/promises");
+const path = require("node:path");
+
 module.exports = function (eleventyConfig) {
     // Copy the contents of the `public` folder to the output folder
     // For example, `./public/css/` ends up in `_site/css/`
@@ -34,6 +37,16 @@ module.exports = function (eleventyConfig) {
         "./node_modules/@gouvfr/dsfr/dist/dsfr.nomodule.min.js": "/js/dsfr.nomodule.min.js",
         "./node_modules/@gouvfr/dsfr/dist/artwork": "/artwork",
         "./node_modules/keycloak-js/lib/keycloak.js": "/js/keycloak.js",
+    });
+
+    // Also copy favicons in the root folder to avoid 404 from pages that don't have
+    // an explicit <link rel="icon"...> (in other apps on the same domain)
+    eleventyConfig.on("eleventy.after", async ({ dir }) => {
+        await fs.cp(
+            path.join(dir.output, "favicon"),
+            path.join(dir.output, ""),
+            { recursive: true }
+        );
     });
 
     // Run Eleventy when these files change:

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -28,7 +28,6 @@ module.exports = function (eleventyConfig) {
     // For example, `./public/css/` ends up in `_site/css/`
     eleventyConfig.addPassthroughCopy({
         "./public/": "/",
-        "./node_modules/@gouvfr/dsfr/dist/favicon": "/favicon",
         "./node_modules/@gouvfr/dsfr/dist/fonts": "/css/fonts",
         "./node_modules/@gouvfr/dsfr/dist/icons": "/css/icons",
         "./node_modules/@gouvfr/dsfr/dist/dsfr.min.css": "/css/dsfr.min.css",
@@ -39,7 +38,7 @@ module.exports = function (eleventyConfig) {
         "./node_modules/keycloak-js/lib/keycloak.js": "/js/keycloak.js",
     });
 
-    // Also copy favicons in the root folder to avoid 404 from pages that don't have
+    // Copy favicons in the root folder to avoid 404 from pages that don't have
     // an explicit <link rel="icon"...> (in other apps on the same domain)
     eleventyConfig.on("eleventy.after", async ({ dir }) => {
         await fs.cp(

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -28,6 +28,7 @@ module.exports = function (eleventyConfig) {
     // For example, `./public/css/` ends up in `_site/css/`
     eleventyConfig.addPassthroughCopy({
         "./public/": "/",
+        "./node_modules/@gouvfr/dsfr/dist/favicon": "/", // copy favicons in the root folder to avoid 404 from pages that don't have an explicit <link rel="icon"...> (in other apps on the same domain)
         "./node_modules/@gouvfr/dsfr/dist/fonts": "/css/fonts",
         "./node_modules/@gouvfr/dsfr/dist/icons": "/css/icons",
         "./node_modules/@gouvfr/dsfr/dist/dsfr.min.css": "/css/dsfr.min.css",
@@ -36,16 +37,6 @@ module.exports = function (eleventyConfig) {
         "./node_modules/@gouvfr/dsfr/dist/dsfr.nomodule.min.js": "/js/dsfr.nomodule.min.js",
         "./node_modules/@gouvfr/dsfr/dist/artwork": "/artwork",
         "./node_modules/keycloak-js/lib/keycloak.js": "/js/keycloak.js",
-    });
-
-    // Copy favicons in the root folder to avoid 404 from pages that don't have
-    // an explicit <link rel="icon"...> (in other apps on the same domain)
-    eleventyConfig.on("eleventy.after", async ({ dir }) => {
-        await fs.cp(
-            path.join(dir.output, "favicon"),
-            path.join(dir.output, ""),
-            { recursive: true }
-        );
     });
 
     // Run Eleventy when these files change:


### PR DESCRIPTION
Copie tout le contenu du dossier favicon du dsfr à la racine du site.

Modifie le gabarit de base pour changer les paths des fichiers concernés.

Le catalogue notamment génère des requêtes vers /favicon.ico qui loguent des 404. C'est pour éviter de noyer les "vrais" erreurs 404 au milieu de ça.