### PR TITLE
fix: largeur et titre actus (#25 et #78)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 _site/
 node_modules/
+public/files/

--- a/_includes/layouts/page.njk
+++ b/_includes/layouts/page.njk
@@ -8,10 +8,12 @@ layout: layouts/base.njk
           {% if showBreadcrumb %}
             {% include "components/breadcrumb.njk" %}
           {% endif %}
-          {% if hasLoader %}
-            <h1>{{ effectiveTitle if effectiveTitle else title }} <span id="loader" class="fr-icon-refresh-line fr-icon--lg frx-icon-spin"></span></h1>
-          {% else %}
-            <h1>{{ effectiveTitle if effectiveTitle else title }}</h1>
+          {% if showTitle %}
+            {% if hasLoader %}
+              <h1>{{ effectiveTitle if effectiveTitle else title }} <span id="loader" class="fr-icon-refresh-line fr-icon--lg frx-icon-spin"></span></h1>
+            {% else %}
+              <h1>{{ effectiveTitle if effectiveTitle else title }}</h1>
+            {% endif %}
           {% endif %}
           {% if description %}
             <p class="fr-text--lead">

--- a/content/accessibilite/index.md
+++ b/content/accessibilite/index.md
@@ -3,6 +3,7 @@ title: "Accessibilité"
 effectiveTitle: "Accessibilité : partiellement conforme"
 layout: layouts/page.njk
 showBreadcrumb: true
+showTitle: true
 slugOverride: accessibilite
 ---
 

--- a/content/actualites/index.njk
+++ b/content/actualites/index.njk
@@ -2,6 +2,7 @@
 title: Actualités
 layout: layouts/page.njk
 showBreadcrumb: true
+showTitle: false
 eleventyNavigation:
     key: Actualités
     order: 4
@@ -9,7 +10,9 @@ eleventyNavigation:
     nav: main
 ---
 
-<div id="actualites-container"></div>
+<div class="fr-container">
+    <div id="actualites-container" class="fr-container"></div>
+</div>
 
 {% js "body" %}
 <script type="text/javascript" src="/js/actualites.js"></script>

--- a/content/cgu/index.md
+++ b/content/cgu/index.md
@@ -2,6 +2,7 @@
 title: "Conditions générales d’utilisation"
 layout: layouts/page.njk
 showBreadcrumb: true
+showTitle: true
 slugOverride: cgu
 summary:
     visible: true

--- a/content/donnees-personnelles/index.md
+++ b/content/donnees-personnelles/index.md
@@ -2,6 +2,7 @@
 title: "Données à caractère personnel"
 layout: layouts/page.njk
 showBreadcrumb: true
+showTitle: true
 slugOverride: donnees-personnelles
 summary:
   visible: true

--- a/content/mentions-legales/index.md
+++ b/content/mentions-legales/index.md
@@ -2,6 +2,7 @@
 title: "Mentions légales"
 layout: layouts/page.njk
 showBreadcrumb: true
+showTitle: true
 slugOverride: mentions-legales
 ---
 

--- a/content/offres/index.md
+++ b/content/offres/index.md
@@ -2,6 +2,7 @@
 title: Offres
 layout: layouts/page.njk
 showBreadcrumb: true
+showTitle: true
 ---
 
 <div class="fr-col-12 fr-col-lg-8">

--- a/content/plan-du-site/index.md
+++ b/content/plan-du-site/index.md
@@ -2,6 +2,7 @@
 title: "Plan du site"
 layout: layouts/page.njk
 showBreadcrumb: true
+showTitle: true
 ---
 
 <div class="fr-my-2w">

--- a/public/js/actualites.js
+++ b/public/js/actualites.js
@@ -72,9 +72,6 @@ function fetchAndInsert(path) {
                 }
             });
 
-            // Retire le h1 Actualités (qui ferait doublon avec le titre réel de la page)
-            result = tmp.innerHTML.replace("<h1>Actualités</h1>", "");
-
             // Insère le contenu
             document.getElementById("actualites-container").innerHTML = result;
 


### PR DESCRIPTION
N'affiche plus de h1 Actualités et fait confiance au contenu récupéré pour avoir un h1 (corrige #78)
En conséquence toutes les pages utilisant le gabarit `layouts/page.njk` déclarent explicitement une propriété `showTitle`.

Ajoute un double `fr-container` autour du contenu des actualités pour avoir une largeur qui correspond au backend (corrige #25). Le fil d'ariane reste aligné avec le header. Seul le contenu récupéré des actus est imbriqué ainsi.