### PR TITLE
fix(lettre d'information) : correctif du html

### DIFF
--- a/content/lettre-d-information/desinscription/desinscription.njk
+++ b/content/lettre-d-information/desinscription/desinscription.njk
@@ -19,18 +19,16 @@ hideNewsletterBanner: true
         <div class="newsletterForm">
             <h2 class="fr-h6 fr-mb-5w">Formulaire de désinscription</h2>
             <form id="unsubscription-form" action="https://analytics-eu.clickdimensions.com/forms/h/agy23ImqvZ0uGZK4anXJmm" method="post">
-                <fieldset class="fr-fieldset fr-mb-5w" aria-labelledby="text-legend text-messages">
-                    <div class="fr-fieldset__element fr-mb-0">
-                        <div id="mail-input-group" class="fr-input-group">
-                            <label class="fr-label" for="text-1">
-                                Adresse électronique
-                                <span class="fr-hint-text">Format attendu : nom@domaine.fr</span>
-                            </label>
-                            <input class="fr-input" name="contact_email" type="email" autocomplete="email">
-                        </div>
+                <div class="fr-mb-5w">
+                    <div id="mail-input-group" class="fr-input-group">
+                        <label class="fr-label" for="text-1">
+                            Adresse électronique
+                            <span class="fr-hint-text">Format attendu : nom@domaine.fr</span>
+                        </label>
+                        <input class="fr-input" name="contact_email" type="email" autocomplete="email" aria-describedby="input-mail-messages-group">
                     </div>
-                    <div id="input-mail-messages-group" class="fr-messages-group" id="text-messages" aria-live="polite"></div>
-                </fieldset>
+                </div>
+                <div id="input-mail-messages-group" class="fr-messages-group" id="text-messages" aria-live="polite"></div>
 
                 <button id="newsletter-unsubscription-submit-btn" class="fr-btn hidden" type="submit">Me désinscrire</button>
             </form>

--- a/content/lettre-d-information/lettre-d-information.njk
+++ b/content/lettre-d-information/lettre-d-information.njk
@@ -18,27 +18,25 @@ hideNewsletterBanner: true
 <div class="fr-container newsletter-container fr-grid-row fr-grid-row--gutters">
     <div class="fr-col-12 fr-col-md">
         <div class="newsletterForm">
-            <h2 class="fr-h3">Formulaire d’inscription</h2>
+            <h2 class="fr-h3">Formulaire d’inscription <span class="fr-hint-text">Tous les champs sont obligatoires</span></h2>
             <form id="subscription-form" method="post" action="https://analytics-eu.clickdimensions.com/forms/h/aploV3fcGl0WA3XfGhD0Z8">
-                <fieldset class="fr-fieldset fr-mb-5w" aria-labelledby="text-legend text-messages">
-                    <div class="fr-fieldset__element">
-                        <div id="mail-input-group" class="fr-input-group">
-                            <label class="fr-label" for="text-1">
-                                Adresse électronique
-                                <span class="fr-hint-text">Format attendu : nom@domaine.fr</span>
-                            </label>
-                            <input class="fr-input" name="contact_email" type="email" autocomplete="email">
-                        </div>
+                <div class="fr-mb-5w">
+                    <div id="mail-input-group" class="fr-input-group">
+                        <label class="fr-label" for="contact_email">
+                            Adresse électronique
+                            <span class="fr-hint-text">Format attendu : nom@domaine.fr</span>
+                        </label>
+                        <input class="fr-input" name="contact_email" id="contact_email" type="email" autocomplete="email" aria-describedby="input-mail-messages-group">
+                        <div id="input-mail-messages-group" class="fr-messages-group" aria-live="polite"></div>
                     </div>
-                    <div id="input-mail-messages-group" class="fr-messages-group" id="text-messages" aria-live="polite"></div>
-                </fieldset>
+                </div>
 
                 <div id="checkbox-input-group" class="fr-checkbox-group">
-                    <input id="checkbox" type="checkbox" aria-describedby="checkbox-messages">
-                    <label class="fr-label" for="checkbox">
+                    <input id="checkbox" type="checkbox" aria-describedby="input-checkbox-messages-group">
+                    <label class="fr-label" for="checkbox-message">
                         <p>J’accepte de recevoir la lettre d’information et je comprends que mes données seront utilisées conformément à <a href="/donnees-personnelles">notre politique des données personnelles</a>.</p>
                     </label>
-                    <div id="input-checkbox-messages-group" class="fr-messages-group" id="checkbox-messages" aria-live="polite"></div>
+                    <div id="input-checkbox-messages-group" class="fr-messages-group" aria-live="polite"></div>
                 </div>
             </form>
             <button class="fr-btn" onclick="sendSubscribeForm()"> S’inscrire </button>

--- a/public/js/newsletter.js
+++ b/public/js/newsletter.js
@@ -23,6 +23,9 @@ let sendSubscribeForm = function() {
     }
     if(isFormValid) {
         document.getElementById("subscription-form").submit();
+        document.title = "S’inscrire à notre lettre d’information | cartes.gouv.fr"
+    } else {
+        document.title = "Erreur - S’inscrire à notre lettre d’information | cartes.gouv.fr"
     }
 };
 
@@ -35,6 +38,9 @@ let sendUnsubscribeForm = function() {
     }
     if(isFormValid) {
         document.getElementById("unsubscription-form").submit();
+        document.title = "Se désinscrire de notre lettre d’information | cartes.gouv.fr"
+    } else {
+         document.title = "Erreur - Se désinscrire de notre lettre d’information | cartes.gouv.fr"
     }
 };
 


### PR DESCRIPTION
Correctif pour l'issue #85

La suppression de la balise `fieldset` diminue de 1rem la marge entre l'input du mail et la checkbox. Je laissé tel quel car ça m'a l'air plus raccord avec ce qu'il y a dans figma et ça évite de faire une surcharge du css juste pour ça.

Pour la mention des champs obligatoires, je ne sais pas exactement ce qui est attendu donc j'ai mis ça dans un `span` dans le titre. J'espère que ça convient.